### PR TITLE
feat: verify self-addressing data

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: Version of Node to use.
     required: false
-    default: 18.x
+    default: 22.x
   install-deps:
     description: Should deps be installed?
     required: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Import 'saidify' and SAIDify your data:
 
 ```typescript
 import saidify from 'saidify'
+
+// create data to become self-addressing
 const myData = {
   a: 1,
   b: 2,
@@ -26,9 +28,14 @@ const myData = {
 const label = 'd'
 const said = deriveSAIDBytes(myData, label)
 console.log(said)
-
 // test assertion with Vitest
 expect(said).toEqual('ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz')
+
+// verify self addressing identifier
+const computedSAID = 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz'
+const doesVerify = verify(myData, computedSAID, label)
+// test assertion
+expect(doesVerify).toEqual(true)
 ```
 
 ## Description

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, test } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import * as Lib from './index.js'
 import { SAIDDex, Serials } from './index.js'
 
@@ -42,7 +42,7 @@ describe('saidify function tests', () => {
 })
 
 describe('example code tests', () => {
-  test(`README and JSDoc code test`, () => {
+  it(`README and JSDoc code test`, () => {
     const data = {
       a: 1,
       b: 2,
@@ -51,5 +51,40 @@ describe('example code tests', () => {
     const label = 'd'
     const said = Lib.saidify(data, SAIDDex.Blake3_256, Serials.JSON, label)
     expect(said).toEqual('ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz')
+  })
+})
+
+describe(`verify function tests`, () => {
+  it(`should verify when only self-addressing data structure passed in`, () => {
+    const data = {
+      a: 1,
+      b: 2,
+      d: 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz',
+    }
+    const doesVerify = Lib.verify(data)
+    expect(doesVerify).toEqual(true)
+  })
+
+  it(`should verify self-addressing data against the SAID`, () => {
+    const said = 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz'
+    const data = {
+      a: 1,
+      b: 2,
+      d: 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz',
+    }
+    const doesVerify = Lib.verify(data, said)
+    expect(doesVerify).toEqual(true)
+  })
+
+  it(`should verify a self-addressing data structure and it's labeled SAID field against a SAID`, () => {
+    const said = 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz'
+    const data = {
+      a: 1,
+      b: 2,
+      d: 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz',
+    }
+    const label = 'd'
+    const doesVerify = Lib.verify(data, said, label, SAIDDex.Blake3_256, Serials.JSON, true)
+    expect(doesVerify).toEqual(true)
   })
 })

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -23,11 +23,11 @@ export const Vrsn_1_1 = new Version(1, 1)
 export const Vrsn_2_0 = new Version(2, 0)
 // Version string in JSON, CBOR, or MGPK field map serialization version 1
 export const VER1FULLSPAN = 17 // number of characters in full version string
-export const VER1TERM = `_`
+export const VER1TERM = `_` // Terminator for CESR v1 version string
 export const VEREX1 = /([A-Z]{4})([0-9a-f])([0-9a-f])([A-Z]{4})([0-9a-f]{6})_/
 // Version string in JSON, CBOR, or MGPK field map serialization version 2
 export const VER2FULLSPAN = 16 // number of characters in full version string
-export const VER2TERM = `.`
+export const VER2TERM = `.` // Terminator for CESR v2 version string
 export const VEREX2 = /([A-Z]{4})([0-9A-Za-z_-])([0-9A-Za-z_-]{2})([A-Z]{4})([0-9A-Za-z_-]{4})\./
 
 // Combined regular expression


### PR DESCRIPTION
Adds a verification function to verify self addressing data and to support verifying it against a provided SAID.

#### TASKS

- [ X ] Out of band docs (website, README, ...)
- [ X ] In of band docs (jsdoc)
- [ X ] Tests
