### PR TITLE
refactor: add self addressing data to return tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ const myData = {
   d: '',
 }
 const label = 'd'
-const said = saidify(myData, label)
+const [said, sad] = saidify(myData, label)
+// said is self-addressing identifier
+// sad is self-addressing data
 console.log(said)
 // ...Vitest test assertion
 expect(said).toEqual('ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz')
 
 // verify self addressing identifier
 const computedSAID = 'ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz'
-const doesVerify = verify(myData, computedSAID, label)
+const doesVerify = verify(sad, computedSAID, label) // can verify with original myData or sad
 // ...Vitest test assertion
 expect(doesVerify).toEqual(true)
 ```

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -21,37 +21,38 @@ describe('saidify function tests', () => {
   })
 
   it(`produces a valid SAID for Blake3-256 algo and JSON serialization with only a data arg`, () => {
-    const saidDataOnly = Lib.saidify(data)
-    expect(saidDataOnly).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
+    const [said, _sad] = Lib.saidify(data)
+    expect(said).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
   })
 
   it(`produces a valid SAID for Blake3-256 and JSON with data and code arg`, () => {
-    const saidDataCode = Lib.saidify(data, 'd', code)
-    expect(saidDataCode).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
+    const [said, _sad] = Lib.saidify(data, 'd', code)
+    expect(said).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
   })
 
   it(`produces a valid SAID for Blake3-256 and JSON with data and kind arg`, () => {
-    const saidDataCodeKind = Lib.saidify(data, 'd', code, kind)
-    expect(saidDataCodeKind).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
+    const [said, _sad] = Lib.saidify(data, 'd', code, kind)
+    expect(said).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
   })
 
   it(`produces a valid SAID for Blake3-256 and JSON with data, code, kind, and label arg`, () => {
-    const saidAllArgs = Lib.saidify(data, label, code, kind)
-    expect(saidAllArgs).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
+    const [said, _sad] = Lib.saidify(data, label, code, kind)
+    expect(said).toEqual(`EHSOlNZzwiekacJenXM3qPNU9-07ic_G0ejn8hrA2lKQ`)
   })
 
   it(`produces a valid SAID for Blake2b-256 and JSON with data, code, kind, and label arg`, () => {
-    const saidAllArgs = Lib.saidify(data, label, code=SAIDDex.Blake2b_256, kind)
-    expect(saidAllArgs).toEqual(`FIzy6Co4x-ynSoF7syuL15Vf82PxldUz05iTGPqiG31u`)
+    const [said, _sad] = Lib.saidify(data, label, code = SAIDDex.Blake2b_256, kind)
+    expect(said).toEqual(`FIzy6Co4x-ynSoF7syuL15Vf82PxldUz05iTGPqiG31u`)
   })
 
   it(`produces a valid SAID for SHA2-256 and JSON with data, code, kind, and label arg`, () => {
-    const saidAllArgs = Lib.saidify(data, label, code=SAIDDex.SHA2_256, kind)
-    expect(saidAllArgs).toEqual(`IOwKVs_pD6kKKw1_eHXI4CUfRfw4mBpvlUuIDdZQXoPr`)})
+    const [said, _sad] = Lib.saidify(data, label, code = SAIDDex.SHA2_256, kind)
+    expect(said).toEqual(`IOwKVs_pD6kKKw1_eHXI4CUfRfw4mBpvlUuIDdZQXoPr`)
+  })
 
   it(`produces a valid SAID for SHA3-256 and JSON with data, code, kind, and label arg`, () => {
-    const saidAllArgs = Lib.saidify(data, label, code=SAIDDex.SHA3_256, kind)
-    expect(saidAllArgs).toEqual(`HLL3GkCKe6HnqkP4ENBWjLlAQVR6Agsw7TVNToyn0lk3`)
+    const [said, _sad] = Lib.saidify(data, label, code = SAIDDex.SHA3_256, kind)
+    expect(said).toEqual(`HLL3GkCKe6HnqkP4ENBWjLlAQVR6Agsw7TVNToyn0lk3`)
   })
 })
 
@@ -63,7 +64,7 @@ describe('example code tests', () => {
       d: '',
     }
     const label = 'd'
-    const said = Lib.saidify(data, label, SAIDDex.Blake3_256, Serials.JSON)
+    const [said, _sad] = Lib.saidify(data, label, SAIDDex.Blake3_256, Serials.JSON)
     expect(said).toEqual('ELLbizIr2FJLHexNkiLZpsTWfhwUmZUicuhmoZ9049Hz')
   })
 })
@@ -99,6 +100,54 @@ describe(`verify function tests`, () => {
     }
     const label = 'd'
     const doesVerify = Lib.verify(data, said, label)
+    expect(doesVerify).toEqual(true)
+  })
+
+  it(`Blake2b-256 SAID matches KERIpy`, () => {
+    const keripySAID = 'FOZ5T-PCxuMDMkl-Vih1BAWcxox5OcclLaxtTcmZcYmr' // got from from KERIpy
+    const data = {
+      d: '',
+      first: 'Sue',
+      last: 'Smith',
+      role: 'Founder',
+    }
+    const label = 'd'
+    const code = SAIDDex.Blake2b_256
+    const [newSaid, sadData] = Lib.saidify(data, label, code, Serials.JSON)
+    expect(newSaid).toEqual(keripySAID)
+    const doesVerify = Lib.verify(sadData, newSaid, label, code)
+    expect(doesVerify).toEqual(true)
+  })
+
+  it(`SHA2-256 SAID matches KERIpy`, () => {
+    const keripySAID = 'IFvJUGAb-3CR_i-34QIg0qJ12-Dnq27pDdgEo3icRdM1' // got from from KERIpy
+    const data = {
+      d: '',
+      first: 'Sue',
+      last: 'Smith',
+      role: 'Founder',
+    }
+    const label = 'd'
+    const code = SAIDDex.SHA2_256
+    const [newSaid, sadData] = Lib.saidify(data, label, code, Serials.JSON)
+    expect(newSaid).toEqual(keripySAID)
+    const doesVerify = Lib.verify(sadData, newSaid, label, code)
+    expect(doesVerify).toEqual(true)
+  })
+
+  it(`SHA3-256 SAID matches KERIpy`, () => {
+    const keripySAID = 'HGQJ4vetZJ_DfufKM0YcTyBXHlR3LxHRu-tOckDHTDM3' // got from from KERIpy
+    const data = {
+      d: '',
+      first: 'Sue',
+      last: 'Smith',
+      role: 'Founder',
+    }
+    const label = 'd'
+    const code = SAIDDex.SHA3_256
+    const [newSaid, sadData] = Lib.saidify(data, label, code, Serials.JSON)
+    expect(newSaid).toEqual(keripySAID)
+    const doesVerify = Lib.verify(sadData, newSaid, label, code)
     expect(doesVerify).toEqual(true)
   })
 })

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -260,6 +260,10 @@ export function validateRawSize(raw: Uint8Array, code: string = SAIDDex.Blake3_2
  * Defaults to using the customary letter `d` as the label. The 'd' stands for digest.
  * Defaults to using Blake3-256 as the derivation algorithm and JSON as the serialization kind.
  *
+ * Returns a tuple of [said, saidified data]
+ *   - said: Self-addressing identifier; the fully qualified Base64 SAID
+ *   - sad: Self-addressing data; the data object with the SAID added to the field labeled by `label`
+ *
  * @example
  *
  * ```ts
@@ -284,9 +288,11 @@ export function saidify(
   label: string = 'd',
   code: string = SAIDDex.Blake3_256,
   kind: Serials = Serials.JSON,
-): string {
-  const [raw, _data] = deriveSAIDBytes(data, code, kind, label)
-  return qb64(raw, code)
+): [string, Dict<any>] {
+  const [raw, sad] = deriveSAIDBytes(data, code, kind, label)
+  const said = qb64(raw, code)
+  sad[label] = said
+  return [said, sad]
 }
 
 /**

--- a/src/lib/digests.ts
+++ b/src/lib/digests.ts
@@ -1,7 +1,7 @@
-import { blake3 } from '@noble/hashes/blake3'
-import { sha3_256 } from '@noble/hashes/sha3'
-import { sha256 } from '@noble/hashes/sha256'
 import { blake2b } from '@noble/hashes/blake2b'
+import { blake3 } from '@noble/hashes/blake3'
+import { sha256 } from '@noble/hashes/sha256'
+import { sha3_256 } from '@noble/hashes/sha3'
 
 /**
  * A base class for lists of things
@@ -63,7 +63,6 @@ export const DigestAlgoMap = new Map<string, Digestage>([
   [SAIDDex.SHA3_256, new Digestage(deriveSHA3_256, 32, 0)],
 ])
 
-
 function deriveBlake3_256(ser: Uint8Array, _digestSize: number | undefined, _length: number | undefined): Buffer {
   return Buffer.from(blake3.create({ dkLen: 32 }).update(ser).digest())
 }
@@ -79,8 +78,3 @@ function deriveSHA2_256(ser: Uint8Array, _digestSize: number | undefined, _lengt
 function deriveSHA3_256(ser: Uint8Array, _digestSize: number | undefined, _length: number | undefined): Buffer {
   return Buffer.from(sha3_256(ser))
 }
-
-
-
-
-


### PR DESCRIPTION
Returns self addressing data dict along with the computed SAID.

#### TASKS

- [ X ] Out of band docs (website, README, ...)
- [ X ] In of band docs (jsdoc)
- [ X ] Tests
